### PR TITLE
replace boost::filesystem::path::normalize() with lexically_normal()

### DIFF
--- a/source/InjectionTk.cpp
+++ b/source/InjectionTk.cpp
@@ -1,3 +1,4 @@
+#define BOOST_FILESYSTEM_VERSION 3
 #include <boost/filesystem.hpp>
 #include <fcntl.h>
 #include "InjectionTk.h"
@@ -32,7 +33,7 @@ void InjectionTk::injectAfterOpen(int fd, std::string path, int flags)
 	{ // normalize path (e.g. remove ".." and "//")
 		boost::filesystem::path pathObj(path);
 
-		std::string pathObjNormalizedStr = pathObj.normalize().string();
+		std::string pathObjNormalizedStr = pathObj.lexically_normal().string();
 
 		// .normalize() leaves a trailing slashdot ("/.") when path ended with "/", so remove that
 		if( (pathObjNormalizedStr.length() > 2) &&


### PR DESCRIPTION
While trying to build this code, I found that recent versions of Boost don't come with boost::filesystem::path::normalize(). The Boost developers recommend replacing it with [lexically_normal()](https://www.boost.org/doc/libs/1_87_0/libs/filesystem/doc/deprecated.html), which has been around since at least version 1.60.

Furthermore, lexically_normal() [no longer emits trailing dots in Boost Filesystem v4](https://www.boost.org/doc/libs/1_87_0/libs/filesystem/doc/reference.html#lexically_normal). To work around these changes, this pull request

- replaces normalize() with lexically_normal()
- `#define BOOST_FILESYSTEM_VERSION 3` so that lexically_normal() always emits trailing dots

This is the simplest solution I could think of.

Whenever C++ 17 gets old enough, you could also consider switching to [std::filesystem](https://en.cppreference.com/w/cpp/filesystem/path/lexically_normal)